### PR TITLE
chore: endpoint standard

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -58,6 +58,7 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'django_nose',
+    'django_filters',
     'rest_framework',
     'backend',
     'users',
@@ -196,3 +197,7 @@ NOSE_ARGS = [
     '--xunit-file=nosetests.xml',  # the XUnit report file
     '--nologcapture'
 ]
+REST_FRAMEWORK = {
+    'DEFAULT_FILTER_BACKENDS': [
+        'django_filters.rest_framework.DjangoFilterBackend']
+}

--- a/backend/backend/urls.py
+++ b/backend/backend/urls.py
@@ -25,6 +25,5 @@ def hello(request):
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('products/', include("products.urls")),
-    path('providers/', include("providers.urls")),
     path('', hello)
 ]

--- a/backend/products/filters.py
+++ b/backend/products/filters.py
@@ -1,8 +1,0 @@
-from products.models import Product
-import django_filters.rest_framework
-
-
-class ProductFilter(django_filters.FilterSet):
-    class Meta:
-        model = Product
-        fields = ['status', 'provider']

--- a/backend/products/filters.py
+++ b/backend/products/filters.py
@@ -1,0 +1,8 @@
+from products.models import Product
+import django_filters.rest_framework
+
+
+class ProductFilter(django_filters.FilterSet):
+    class Meta:
+        model = Product
+        fields = ['status', 'provider']

--- a/backend/products/tests.py
+++ b/backend/products/tests.py
@@ -29,7 +29,7 @@ class RegisterRequestToCreateProduct(TestCase):
         self,
     ) -> None:
         response = self.client.post(
-            reverse("products"),
+            reverse("create_product"),
             data=json.dumps(self.valid_payload),
             content_type="application/json",
         )
@@ -54,7 +54,7 @@ class ListPendingProductRequests(TestCase):
         self,
     ) -> None:
         response = self.client.get(
-            reverse("products"),
+            reverse("list_products"),
             {'status': Product.PENDING},
             content_type="application/json",
         )
@@ -73,7 +73,7 @@ class UpdateProductTest(TestCase):
 
     def test_error_if_product_not_found(self) -> None:
         response = self.client.put(
-            reverse("product_detail", kwargs={'pk': 99999999}),
+            reverse("update_product", kwargs={'pk': 99999999}),
             content_type="application/json",
         )
         self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
@@ -85,7 +85,7 @@ class UpdateProductTest(TestCase):
             new_product,
         ).data
         response = self.client.put(
-            reverse("product_detail", kwargs={'pk': self.product.pk}),
+            reverse("update_product", kwargs={'pk': self.product.pk}),
             data=json.dumps(valid_product),
             content_type="application/json",
         )
@@ -101,14 +101,14 @@ class DetailProductTest(TestCase):
 
     def test_error_if_product_not_found(self) -> None:
         response = self.client.get(
-            reverse("product_detail", kwargs={'pk': 99999999}),
+            reverse("detail_product", kwargs={'pk': 99999999}),
             content_type="application/json",
         )
         self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
 
     def test_get_product_detail(self) -> None:
         response = self.client.get(
-            reverse("product_detail", kwargs={'pk': self.product.pk}),
+            reverse("detail_product", kwargs={'pk': self.product.pk}),
             content_type="application/json"
         )
         self.assertEqual(response.status_code, HTTPStatus.OK)
@@ -136,7 +136,7 @@ class ListAllActiveProductsOfProvider(TestCase):
         self,
     ) -> None:
         response = self.client.get(
-            reverse("products"),
+            reverse("list_products"),
             {
                 'provider': self.provider.id,
                 'status': Product.ACCEPTED

--- a/backend/products/tests.py
+++ b/backend/products/tests.py
@@ -29,7 +29,7 @@ class RegisterRequestToCreateProduct(TestCase):
         self,
     ) -> None:
         response = self.client.post(
-            reverse("request_product"),
+            reverse("products"),
             data=json.dumps(self.valid_payload),
             content_type="application/json",
         )
@@ -54,7 +54,7 @@ class ListPendingProductRequests(TestCase):
         self,
     ) -> None:
         response = self.client.get(
-            reverse("get_list_products"),
+            reverse("products"),
             {'status': Product.PENDING},
             content_type="application/json",
         )
@@ -73,7 +73,7 @@ class UpdateProductTest(TestCase):
 
     def test_error_if_product_not_found(self) -> None:
         response = self.client.put(
-            reverse("manage_product", kwargs={'pk': 99999999}),
+            reverse("product_detail", kwargs={'pk': 99999999}),
             content_type="application/json",
         )
         self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
@@ -85,7 +85,7 @@ class UpdateProductTest(TestCase):
             new_product,
         ).data
         response = self.client.put(
-            reverse("manage_product", kwargs={'pk': self.product.pk}),
+            reverse("product_detail", kwargs={'pk': self.product.pk}),
             data=json.dumps(valid_product),
             content_type="application/json",
         )
@@ -101,14 +101,14 @@ class DetailProductTest(TestCase):
 
     def test_error_if_product_not_found(self) -> None:
         response = self.client.get(
-            reverse("manage_product", kwargs={'pk': 99999999}),
+            reverse("product_detail", kwargs={'pk': 99999999}),
             content_type="application/json",
         )
         self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
 
     def test_get_product_detail(self) -> None:
         response = self.client.get(
-            reverse("manage_product", kwargs={'pk': self.product.pk}),
+            reverse("product_detail", kwargs={'pk': self.product.pk}),
             content_type="application/json"
         )
         self.assertEqual(response.status_code, HTTPStatus.OK)
@@ -136,7 +136,7 @@ class ListAllActiveProductsOfProvider(TestCase):
         self,
     ) -> None:
         response = self.client.get(
-            reverse("get_list_products"),
+            reverse("products"),
             {
                 'provider': self.provider.id,
                 'status': Product.ACCEPTED

--- a/backend/products/urls.py
+++ b/backend/products/urls.py
@@ -3,10 +3,6 @@ from . import views
 
 urlpatterns = [
     path('request/', views.request_product, name="request_product"),
-    path(
-        'products/requests/pending',
-        views.list_pending_products,
-        name="pending_product_requests",
-    ),
+    path('', views.get_list_products, name="get_list_products"),
     path('<int:pk>', views.manage_product, name='manage_product'),
 ]

--- a/backend/products/urls.py
+++ b/backend/products/urls.py
@@ -2,7 +2,6 @@ from django.urls import path
 from . import views
 
 urlpatterns = [
-    path('request/', views.request_product, name="request_product"),
-    path('', views.get_list_products, name="get_list_products"),
-    path('<int:pk>', views.manage_product, name='manage_product'),
+    path('', views.products, name="products"),
+    path('<int:pk>', views.product_detail, name='product_detail'),
 ]

--- a/backend/products/urls.py
+++ b/backend/products/urls.py
@@ -2,6 +2,10 @@ from django.urls import path
 from . import views
 
 urlpatterns = [
-    path('', views.products, name="products"),
-    path('<int:pk>', views.product_detail, name='product_detail'),
+    path('', views.ListProductView.as_view(), name="list_products"),
+    path('create', views.CreateProductView.as_view(), name="create_product"),
+    path('<int:pk>/update',
+         views.UpdateProductView.as_view(), name="update_product"),
+    path('<int:pk>',
+         views.RetrieveProductView.as_view(), name='detail_product'),
 ]

--- a/backend/products/views.py
+++ b/backend/products/views.py
@@ -1,80 +1,31 @@
-from http import HTTPStatus
 from products.models import Product
-from django.shortcuts import get_object_or_404
-
-from rest_framework.decorators import api_view
-from rest_framework.request import Request
-from rest_framework.response import Response
 
 from products.serializers.product import (
     CreateProductSerializer, ProductSerializer,
     UpdateProductSerializer
 )
 
-from products.filters import ProductFilter
-from django_filters.utils import translate_validation
+from django_filters.rest_framework import DjangoFilterBackend
+from rest_framework import generics
 
 
-@api_view(["POST", "GET"])
-def products(request: Request) -> Response:
-    if request.method == 'POST':
-        data = {
-            "key": request.data.get("key"),
-            "name": request.data.get("name"),
-            "dose": request.data.get("dose"),
-            "presentation": request.data.get("presentation"),
-            "iva": request.data.get("iva"),
-            "price": request.data.get("price"),
-            "more_info": request.data.get("more_info"),
-            "is_generic": request.data.get("is_generic"),
-            "provider": request.data.get("provider"),
-            "status": Product.PENDING,
-        }
-
-        serializer = CreateProductSerializer(data=data)
-
-        if serializer.is_valid():
-            serializer.save()
-            return Response(serializer.data, status=HTTPStatus.CREATED)
-        return Response(serializer.errors, status=HTTPStatus.BAD_REQUEST)
-    elif request.method == 'GET':
-        queryset = Product.objects.all()
-        filterset = ProductFilter(request.GET, queryset=queryset)
-        if not filterset.is_valid():
-            raise translate_validation(filterset.errors)
-        serializer = ProductSerializer(filterset.qs, many=True)
-        return Response(serializer.data)
+class ListProductView(generics.ListAPIView):
+    queryset = Product.objects.all()
+    serializer_class = ProductSerializer
+    filter_backends = [DjangoFilterBackend]
+    filterset_fields = ['provider', 'status']
 
 
-@api_view(["PUT", "GET"])
-def product_detail(request: Request, *args, **kwargs) -> Response:
-    if request.method == 'PUT':
-        pk = kwargs.get("pk")
-        product = get_object_or_404(Product, pk=pk)
-        data = {
-            "key": request.data.get("key"),
-            "name": request.data.get("name"),
-            "dose": request.data.get("dose"),
-            "presentation": request.data.get("presentation"),
-            "iva": request.data.get("iva"),
-            "price": request.data.get("price"),
-            "more_info": request.data.get("more_info"),
-            "is_generic": request.data.get("is_generic"),
-            "provider": request.data.get("provider"),
-            "status": request.data.get("status")
-        }
+class CreateProductView(generics.CreateAPIView):
+    queryset = Product.objects.all()
+    serializer_class = CreateProductSerializer
 
-        serializer = UpdateProductSerializer(instance=product, data=data)
-        if serializer.is_valid():
-            serializer.save()
-            return Response(serializer.data, status=HTTPStatus.OK)
-        print(serializer.errors)
-        return Response(serializer.errors, status=HTTPStatus.BAD_REQUEST)
 
-    elif request.method == 'GET':
-        pk = kwargs.get("pk")
-        product = get_object_or_404(Product, pk=pk)
+class UpdateProductView(generics.UpdateAPIView):
+    queryset = Product.objects.all()
+    serializer_class = UpdateProductSerializer
 
-        serializer = ProductSerializer(product)
 
-        return Response(serializer.data, status=HTTPStatus.OK)
+class RetrieveProductView(generics.RetrieveAPIView):
+    queryset = Product.objects.all()
+    serializer_class = ProductSerializer

--- a/backend/products/views.py
+++ b/backend/products/views.py
@@ -15,41 +15,39 @@ from products.filters import ProductFilter
 from django_filters.utils import translate_validation
 
 
-@api_view(["POST"])
-def request_product(request: Request) -> Response:
-    data = {
-        "key": request.data.get("key"),
-        "name": request.data.get("name"),
-        "dose": request.data.get("dose"),
-        "presentation": request.data.get("presentation"),
-        "iva": request.data.get("iva"),
-        "price": request.data.get("price"),
-        "more_info": request.data.get("more_info"),
-        "is_generic": request.data.get("is_generic"),
-        "provider": request.data.get("provider"),
-        "status": Product.PENDING,
-    }
+@api_view(["POST", "GET"])
+def products(request: Request) -> Response:
+    if request.method == 'POST':
+        data = {
+            "key": request.data.get("key"),
+            "name": request.data.get("name"),
+            "dose": request.data.get("dose"),
+            "presentation": request.data.get("presentation"),
+            "iva": request.data.get("iva"),
+            "price": request.data.get("price"),
+            "more_info": request.data.get("more_info"),
+            "is_generic": request.data.get("is_generic"),
+            "provider": request.data.get("provider"),
+            "status": Product.PENDING,
+        }
 
-    serializer = CreateProductSerializer(data=data)
+        serializer = CreateProductSerializer(data=data)
 
-    if serializer.is_valid():
-        serializer.save()
-        return Response(serializer.data, status=HTTPStatus.CREATED)
-    return Response(serializer.errors, status=HTTPStatus.BAD_REQUEST)
-
-
-@api_view(["GET"])
-def get_list_products(request: Request) -> Response:
-    queryset = Product.objects.all()
-    filterset = ProductFilter(request.GET, queryset=queryset)
-    if not filterset.is_valid():
-        raise translate_validation(filterset.errors)
-    serializer = ProductSerializer(filterset.qs, many=True)
-    return Response(serializer.data)
+        if serializer.is_valid():
+            serializer.save()
+            return Response(serializer.data, status=HTTPStatus.CREATED)
+        return Response(serializer.errors, status=HTTPStatus.BAD_REQUEST)
+    elif request.method == 'GET':
+        queryset = Product.objects.all()
+        filterset = ProductFilter(request.GET, queryset=queryset)
+        if not filterset.is_valid():
+            raise translate_validation(filterset.errors)
+        serializer = ProductSerializer(filterset.qs, many=True)
+        return Response(serializer.data)
 
 
 @api_view(["PUT", "GET"])
-def manage_product(request: Request, *args, **kwargs) -> Response:
+def product_detail(request: Request, *args, **kwargs) -> Response:
     if request.method == 'PUT':
         pk = kwargs.get("pk")
         product = get_object_or_404(Product, pk=pk)

--- a/backend/providers/urls.py
+++ b/backend/providers/urls.py
@@ -1,7 +1,0 @@
-from django.urls import path
-from products.views import list_all_products
-
-urlpatterns = [
-    path('<int:pk>/products', list_all_products,
-         name="list_all_products"),
-]


### PR DESCRIPTION
¿Qué hace este PR?
Cambia las vistas existentes para intentar aplicar los estandares propuestos de nombres de endpoint. De esa forma, podemos tener un estandar que se puede aprovechar en frontend. Se pueden poner los campos que pueden buscarse por filtros en las vistas de listas.