### PR TITLE
[GAQ-149] fix: hide sidenavbar group if no visible children provided

### DIFF
--- a/frontend/src/components/SideMenu/SideMenu.tsx
+++ b/frontend/src/components/SideMenu/SideMenu.tsx
@@ -26,7 +26,16 @@ const SideMenu: React.FC<{groups: RegisteredGroup}> = ({ groups }) => {
       >
         {Object.values(groups).map(
           (group) => {
-            if (!group.showInMenu) { return null; }
+            const groupRoutes = Object.values(group.routes);
+
+            const visibibleRoutes = groupRoutes.filter(
+              (route) => (route.showInMenu
+                 && (route.hasAccess ? route.hasAccess(auth) : true)),
+            );
+
+            if (!group.showInMenu || visibibleRoutes.length <= 0) {
+              return null;
+            }
 
             const Icon = group.icon || FileDoneOutlined;
 
@@ -36,7 +45,7 @@ const SideMenu: React.FC<{groups: RegisteredGroup}> = ({ groups }) => {
                 icon={<Icon />}
                 title={group.verboseName}
               >
-                {Object.values(group.routes).map(
+                {visibibleRoutes.map(
                   (route) => {
                     if (!route.showInMenu || (
                       route.hasAccess && !route.hasAccess(auth))) {


### PR DESCRIPTION
## ¿Qué hace este PR?
- Cambia el componente de SideMenu para esconder el grupo de rutas de navegación si es que no tiene hijos o rutas disponibles para ese grupo. Por ejemplo, un cliente no tiene o no deberia tener rutas disponibles del grupo de Laboratorios, pero le salia el grupo vacio.

## ¿Cuáles son los tickets relevantes de JIRA?
- GAQ-149
