### PR TITLE
feat: change user active status and send admin mails on product price change [GAQ-50]

### DIFF
--- a/backend/backend/utils/emails.py
+++ b/backend/backend/utils/emails.py
@@ -1,0 +1,12 @@
+from django.contrib.auth.models import User
+
+from backend.utils.constants import ADMIN_GROUP
+
+
+def get_admin_emails() -> list:
+    user_emails = list(
+        User.objects.filter(
+            groups__name=ADMIN_GROUP
+        ).values_list('email', flat=True)
+    )
+    return user_emails

--- a/backend/products/mails.py
+++ b/backend/products/mails.py
@@ -1,13 +1,10 @@
-from typing import Optional
-
-from products.models import Product, ChangePriceRequest
+from backend.utils.emails import get_admin_emails
+from products.models import Product
 from django.dispatch import receiver
 from django.core import mail
 from django.db.models.signals import post_save
 from django.template.loader import render_to_string
 from django.utils.html import strip_tags
-
-from users.models import UserEmail
 
 
 @receiver(post_save, sender=Product)
@@ -36,56 +33,25 @@ def send_mail_on_create(sender, instance=None, created=False, **kwargs):
             html_message=html_message,
             fail_silently=True,
         )
-    else:
-        title = "Actualización de Producto"
-        subject = f"GAQSA - {title}"
-        context = {
-            "provider": instance.provider,
-            "product": instance,
-            "title": title
-        }
-        from_email = "noreply@gaqsa.com"
-        # TODO: Cambiar correo de admin
-        to_emails = [instance.provider.user.email, "admin@temp.com"]
-        html_message = render_to_string(
-            "product_updated.html",
-            context
-        )
-        plain_message = strip_tags(html_message)
-        mail.send_mail(
-            subject,
-            plain_message,
-            from_email,
-            to_emails,
-            html_message=html_message,
-            fail_silently=True,
-        )
 
 
-@receiver(post_save, sender=ChangePriceRequest)
-def send_mail_on_request_price_change(
-    sender,
-    instance: Optional[ChangePriceRequest] = None,
-    created=False,
+def send_mail_on_price_change(
+    products,
+    provider,
+    *args,
     **kwargs,
 ) -> None:
-    if not instance:
-        return None
 
-    title = "Solicitud de Cambio de Precio de Producto"
+    title = "Modificación Lista Precios de Proveedor " + provider.name
     subject = f"GAQSA - {title}"
     context = {
-        "provider": instance.provider,
-        "product": instance.product,
-        "new_price": instance.new_price,
+        "products": products,
+        "provider": provider,
         "title": title,
     }
     from_email = "noreply@gaqsa.com"
-    provider_emails = list(UserEmail.objects.filter(
-        user=instance.provider.user, category=UserEmail.PRICE_CHANGE
-    ).values_list('email', flat=True))
-    # TODO: Cambiar correo de admin
-    to_emails = provider_emails + ["admin@temp.com"]
+    to_emails = get_admin_emails()
+
     html_message = render_to_string(
         "change_price_request.html",
         context

--- a/backend/products/templates/change_price_request.html
+++ b/backend/products/templates/change_price_request.html
@@ -7,38 +7,44 @@
     <h4>{{ provider.name}}</h4>
     <h4>RFC: {{ provider.rfc }}</h4>
   </div>
-  <h4>Se ha solicitado modificación del precio un producto</h4>
-  <h3>Precio actual: $ {{ product.price }}</h3>
-  <h3>Nuevo precio: $ {{ new_price }}</h3>
+
   <table style="width:100%">
-    <tr>
-      <th>
-        Atributo
-      </th>
-      <th>
-        Valor
-      </th>
-    </tr>
-    <tr>
-      <td>Nombre</td>
-      <td>{{ product.name }}</td>
-    </tr>
-    <tr>    
-      <td>Presentación</td>
-      <td>{{ product.presentation }}</td>
-    </tr>
-    <tr>    
-      <td>Laboratorio</td>
-      <td>{{ product.laboratory }}</td>
-    </tr>
-    <tr>    
-      <td>Categoría</td>
-      <td>{{ product.category }}</td>
-    </tr>
-    <tr>    
-      <td>Precio</td>
-      <td>{{ product.price }}</td>
-    </tr>
+    <th>Clave</th>
+    <th>Producto</th>
+    <th>Presentación</th>
+    <th>Laboratorio</th>
+    <th>Precio anterior</th>
+    <th>Precio nuevo</th>
+    <th>Diferencia precio</th>
+    <th>%</th>
+    {% for product in products %}
+      <tr {% if product.price_diff <= 0 %} style="background-color: #50d941" {% else %} style="background-color: #ede728" {% endif %}>
+        <td>
+          {{ product.key }}
+        </td>
+        <td>
+          {{ product.name }}
+        </td>
+        <td>
+          {{ product.presentation }}
+        </td>
+        <td>
+          {{ product.laboratory.name }}
+        </td>
+        <td>
+          $ {{ product.old_price }}
+        </td>
+        <td>
+          $ {{ product.price}}
+        </td>
+        <td>
+          $ {{ product.price_diff }}
+        </td>
+        <td>
+          {{ product.diff_percentage }} %
+        </td>
+      </tr>
+    {% endfor %}
   </table>
 {% endblock %}
 

--- a/backend/products/tests.py
+++ b/backend/products/tests.py
@@ -180,7 +180,6 @@ class UpdateProduct(BaseTestCase):
         self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
 
     def test_update_product_test(self) -> None:
-        mail.outbox = []
         new_product = self.product
         new_product.status = Product.ACCEPTED
         valid_product = UpdateProductSerializer(
@@ -199,7 +198,6 @@ class UpdateProduct(BaseTestCase):
         # Creates new m2m animal group relation instances
         self.assertEqual(len(response.data["animal_groups"]),
                          len(self.animal_groups))
-        self.assertGreater(len(mail.outbox), 0)
 
 
 class DetailProduct(BaseTestCase):
@@ -364,6 +362,7 @@ class RequestProductPriceChange(BaseTestCase):
         }
 
     def test_product_price_change_request_should_be_successful(self) -> None:
+        mail.outbox = []
         response = self.provider_client.post(
             reverse("request_price_change"),
             data=json.dumps(self.valid_payload),
@@ -375,6 +374,7 @@ class RequestProductPriceChange(BaseTestCase):
         self.products[0].refresh_from_db(fields=["price"])
         self.assertEqual(self.products[0].price, self.expected_price)
         self.assertEqual(self.provider.token_used, True)
+        self.assertGreater(len(mail.outbox), 0)
 
     def test_product_price_change_request_should_fail_with_no_access(
             self,

--- a/backend/users/serializers/users.py
+++ b/backend/users/serializers/users.py
@@ -47,3 +47,9 @@ class ListUserSerializer(serializers.ModelSerializer):
             "provider",
             "client"
         )
+
+
+class UserIsActiveSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = User
+        fields = ('is_active', 'pk')

--- a/backend/users/tests.py
+++ b/backend/users/tests.py
@@ -297,7 +297,6 @@ class ListAllUsers(BaseTestCase):
         self.assertEqual(response.status_code, HTTPStatus.OK)
 
         result = json.loads(json.dumps(response.data))
-        print(result)
         self.assertEqual(len(result), self.users_quantity + 3)
 
 

--- a/backend/users/tests.py
+++ b/backend/users/tests.py
@@ -32,6 +32,10 @@ class UserLogin(TestCase):
     def setUp(self) -> None:
         self.password = sfaker.password()
         self.user = UserFactory.create(password=make_password(self.password))
+        self.inactive_user = UserFactory.create(
+            password=make_password(self.password),
+            is_active=False
+        )
 
     def test_login_with_invalid_data_should_fail(
         self,
@@ -73,6 +77,19 @@ class UserLogin(TestCase):
         self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertNotEqual(response.data['access'], None)
         self.assertNotEqual(response.data['refresh'], None)
+
+    def test_login_with_not_active_user_should_fail(
+        self,
+    ) -> None:
+        response = self.client.post(
+            reverse("login"),
+            data={
+                'username': self.inactive_user.username,
+                'password': self.password
+            },
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
 
     def test_refresh_with_valid_token_should_succeed(
         self,
@@ -282,3 +299,70 @@ class ListAllUsers(BaseTestCase):
         result = json.loads(json.dumps(response.data))
         print(result)
         self.assertEqual(len(result), self.users_quantity + 3)
+
+
+class ToggleUserActive(BaseTestCase):
+    def setUp(self) -> None:
+        self.active_user = UserFactory.create()
+        self.unactive_user = UserFactory.create(
+            is_active=False
+        )
+        self.active_payload = json.dumps({
+            "is_active": True,
+        })
+
+        self.unactive_payload = json.dumps({
+            'is_active': False,
+        })
+
+    def test_require_authentication(
+        self,
+    ) -> None:
+        response = self.anonymous.patch(
+            reverse("user-active", kwargs={"pk": self.active_user.pk}),
+            content_type="application/json",
+            data=self.active_payload
+        )
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
+
+    def test_require_admin_role(
+        self,
+    ) -> None:
+        response = self.service_client.patch(
+            reverse("user-active", kwargs={"pk": self.active_user.pk}),
+            content_type="application/json",
+            data=self.active_payload
+        )
+        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
+        response = self.provider_client.patch(
+            reverse("user-active", kwargs={"pk": self.active_user.pk}),
+            content_type="application/json",
+            data=self.active_payload
+        )
+        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
+
+    def test_activate_user_should_succeed(
+        self,
+    ) -> None:
+        self.assertEqual(self.unactive_user.is_active, False)
+        response = self.admin_client.patch(
+            reverse("user-active", kwargs={"pk": self.unactive_user.pk}),
+            content_type="application/json",
+            data=self.active_payload
+        )
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.unactive_user.refresh_from_db(fields=["is_active"])
+        self.assertEqual(self.unactive_user.is_active, True)
+
+    def test_deactivate_user_should_succeed(
+        self,
+    ) -> None:
+        self.assertEqual(self.active_user.is_active, True)
+        response = self.admin_client.patch(
+            reverse("user-active", kwargs={"pk": self.active_user.pk}),
+            content_type="application/json",
+            data=self.unactive_payload
+        )
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.active_user.refresh_from_db(fields=["is_active"])
+        self.assertEqual(self.active_user.is_active, False)

--- a/backend/users/urls.py
+++ b/backend/users/urls.py
@@ -1,6 +1,9 @@
 from django.urls import path
 
-from users.views import CreateUser, CustomTokenObtainPairView, ListUserView
+from users.views import (
+    CreateUser, CustomTokenObtainPairView,
+    UpdateUserActiveView, ListUserView
+)
 from rest_framework_simplejwt.views import (
     TokenRefreshView,
 )
@@ -10,5 +13,7 @@ urlpatterns = [
     path('refresh/', TokenRefreshView.as_view(),
          name='token_refresh'),
     path('create', CreateUser.as_view(), name='create-user'),
-    path('', ListUserView.as_view(), name='list_users')
+    path('', ListUserView.as_view(), name='list_users'),
+    path('<int:pk>/active', UpdateUserActiveView.as_view(),
+         name='user-active'),
 ]

--- a/frontend/src/components/PriceChangeForm/PriceChangeForm.tsx
+++ b/frontend/src/components/PriceChangeForm/PriceChangeForm.tsx
@@ -76,6 +76,8 @@ const PriceChangeForm: React.FC<Props> = ({
               formatter={(value) => `$${value}`.replace(
                 /\B(?=(\d{3})+(?!\d))/g, ',',
               )}
+              precision={2}
+              step={0.01}
             />
           </Form.Item>
           <Form.Item

--- a/frontend/src/views/Products.ListProducts/Products.ListProducts.tsx
+++ b/frontend/src/views/Products.ListProducts/Products.ListProducts.tsx
@@ -285,7 +285,11 @@ const ListProducts: React.VC = ({ verboseName, parentName }) => {
               <Table
                 rowKey={(row) => `${row.id}`}
                 data={filtered}
-                columns={columns}
+                columns={isAdmin
+                  ? columns
+                  : columns.filter(
+                    (column) => column.key !== 'provider',
+                  )}
                 actions={[
                   {
                     action: changePriceButton,

--- a/frontend/src/views/Users.ListUsers/Users.ListUsers.styled.tsx
+++ b/frontend/src/views/Users.ListUsers/Users.ListUsers.styled.tsx
@@ -1,0 +1,7 @@
+import styled from 'styled-components';
+
+export const Actions = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+`;

--- a/frontend/src/views/Users.ListUsers/Users.ListUsers.tsx
+++ b/frontend/src/views/Users.ListUsers/Users.ListUsers.tsx
@@ -56,12 +56,12 @@ const ListUsers: React.VC = ({ verboseName, parentName }) => {
     );
     if (error || !result) {
       notification.error({
-        message: 'Ocurrió un error al modificar el acceso al usuario!',
+        message: 'Ocurrió un error al modificar el acceso del usuario!',
         description: 'Intentalo más tarde',
       });
     }
     notification.success({
-      message: !activate ? 'El usuario se ha desactiado exitosamente.'
+      message: !activate ? 'El usuario se ha desactivado exitosamente.'
         : 'El usuario se ha activado exitosamente.',
     });
     fetchUsers();

--- a/frontend/tools/generate.js
+++ b/frontend/tools/generate.js
@@ -78,6 +78,21 @@ generateTemplateFiles([
         },
     },
     {
+        option: 'Create Modal',
+        defaultCase: '(pascalCase)',
+        entry: {
+            folderPath: './tools/templates/Modal',
+        },
+        stringReplacers: ['__name__'],
+        output: {
+            path: './src/components/Modals/__name__Modal',
+            pathAndFileNameDefaultCase: '(pascalCase)',
+        },
+        onComplete: (results) => {
+            console.log(`results`, results);
+        },
+    },
+    {
         option: 'Create Generic Component',
         defaultCase: '(pascalCase)',
         entry: {
@@ -107,4 +122,5 @@ generateTemplateFiles([
             console.log(`results`, results);
         },
     },
+
 ]);

--- a/frontend/tools/templates/Modal/__name__Modal.tsx
+++ b/frontend/tools/templates/Modal/__name__Modal.tsx
@@ -1,0 +1,68 @@
+import {
+  Modal,
+  notification,
+  Typography,
+} from 'antd';
+import { useBackend } from 'integrations';
+import React, { useState } from 'react';
+import { Props } from './__name__Modal.type';
+
+const __name__Modal: React.FC<Props> = ({
+  visible, onClose,
+}) => {
+  const [loading, setLoading] = useState(false);
+  const backend = useBackend();
+
+  const handleUpdate = async (data: any): Promise<void> => {
+    setLoading(true);
+
+    const payload = { ...data };
+    /* const [response, error] = await backend...
+
+    if (error || !response || !response.data) {
+      notification.error({
+        message: 'Error',
+      });
+      setLoading(false);
+      return;
+    }
+
+    notification.success({
+      message: (
+        ''
+      ),
+    });
+    */
+    setLoading(false);
+    onClose();
+  };
+
+  const handleOk = async (): Promise<void> => {
+    try {
+      const values = {};
+      await handleUpdate(values);
+    } catch (info) {
+      notification.error({
+        message: 'Error.',
+      });
+    }
+  };
+
+  return (
+    <Modal
+      visible={visible}
+      onCancel={onClose}
+      onOk={handleOk}
+      okText="Confirmar"
+      cancelText="Cancelar"
+      title={`Titulo`}
+      confirmLoading={loading}
+    >
+      <Typography.Text strong>
+        Modal
+      </Typography.Text>
+    </Modal>
+  );
+};
+
+export default __name__Modal;

--- a/frontend/tools/templates/Modal/__name__Modal.type.ts
+++ b/frontend/tools/templates/Modal/__name__Modal.type.ts
@@ -1,0 +1,4 @@
+export interface Props {
+  visible: boolean;
+  onClose: () => void;
+}

--- a/frontend/tools/templates/Modal/index.ts
+++ b/frontend/tools/templates/Modal/index.ts
@@ -1,0 +1,1 @@
+export { default } from './__name__Modal';


### PR DESCRIPTION
## ¿Qué hace este PR?
- Permite al administrador activar y desactivar usuarios para que no puedan interactuar con el sistema.
- Un usuario desactivado no puede iniciar sesión, y cualquier petición que haga un usuario desactivado que ya estaba autenticado regresa un error.
- Elimina la señal de enviar un correo al modificar un producto. Esto provocaba spam al momento de hacer cambio de precios masivo ademas que el proveedor no puede cambiar nada del producto mas que el precio entonces esto se elimina para remplazarlo con el correo personalizado de aplicacion de cambio de precios.
- Envía correo con listado de productos y sus nuevos precios a los admins cuando un proveedor aplica un código de cambio de precios.
- Agrega modal genérico como template en el generador de frontend
- Agrega utilidad para obtener todos los correos de los usuarios con rol administrador.
 
## ¿Cuáles son los tickets relevantes de JIRA?
- GAQ-50 se cierra con esto.

## Screenshots (Si aplica)
https://user-images.githubusercontent.com/38927620/140568772-05aedc5e-37a5-43d3-b77d-e15e95b5db5a.mp4

![image](https://user-images.githubusercontent.com/38927620/140568816-7c84e5b3-ed33-4c50-94f3-48654f5071c8.png)
