### PR TITLE
feat: add and remove provider from existing product [GAQ-225, GAQ-228]

### DIFF
--- a/backend/backend/utils/tests.py
+++ b/backend/backend/utils/tests.py
@@ -1,3 +1,4 @@
+import logging
 from backend.utils.constants import ADMIN_GROUP, CLIENT_GROUP, PROVIDER_GROUP
 from users.factories.user import UserFactory
 from django.test import TestCase
@@ -10,6 +11,7 @@ class BaseTestCase(TestCase):
 
     @classmethod
     def setUpTestData(cls) -> None:
+        logging.disable(logging.WARNING)
 
         cls.provider_user = UserFactory.create()
         provider_group = Group.objects.get(name=PROVIDER_GROUP)

--- a/backend/products/serializers/product.py
+++ b/backend/products/serializers/product.py
@@ -15,6 +15,12 @@ class CreateProductProviderSerializer(serializers.ModelSerializer):
         exclude = ('id', 'product')
 
 
+class AddProviderToProductSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = ProductProvider
+        exclude = ('id', )
+
+
 class UpdateProductProviderSerializer(serializers.ModelSerializer):
     class Meta:
         model = ProductProvider

--- a/backend/products/tests.py
+++ b/backend/products/tests.py
@@ -678,6 +678,14 @@ class AddProviderToProduct(BaseTestCase):
         )
         self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
 
+    def test_return_404_on_invalid_product(self) -> None:
+        response = self.admin_client.post(
+            reverse("add_provider", kwargs={'pk': 9999}),
+            data=json.dumps(self.valid_payload),
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
+
     def test_valid_add_provider_to_product_request_should_succeed(
         self,
     ) -> None:
@@ -688,3 +696,71 @@ class AddProviderToProduct(BaseTestCase):
         )
         self.assertEqual(response.status_code, HTTPStatus.CREATED)
         self.assertGreater(len(self.target_product.providers), 0)
+
+
+class RemoveProviderFromProduct(BaseTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        provider = ProviderFactory.create()
+        product = ProductFactory.create()
+        self.product_provider = ProductProviderFactory.create(
+            provider=provider,
+            product=product
+        )
+
+    def test_require_authentication(self) -> None:
+        response = self.anonymous.delete(
+            reverse(
+                "delete_product_provider",
+                kwargs={
+                    'pk': self.product_provider.pk,
+                }),
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
+
+    def test_require_admin(self) -> None:
+        response = self.provider_client.delete(
+            reverse(
+                "delete_product_provider",
+                kwargs={
+                    'pk': self.product_provider.pk,
+                }),
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
+        response = self.service_client.delete(
+            reverse(
+                "delete_product_provider",
+                kwargs={
+                    'pk': self.product_provider.pk,
+                }),
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
+
+    def test_return_404_on_invalid_productprovider(self) -> None:
+        response = self.admin_client.delete(
+            reverse(
+                "delete_product_provider",
+                kwargs={
+                    'pk': 9999,
+                }),
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
+
+    def test_remove_provider_from_product_should_succeed(
+        self,
+    ) -> None:
+        response = self.admin_client.delete(
+            reverse(
+                "delete_product_provider",
+                kwargs={
+                    'pk': self.product_provider.pk,
+                }),
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        with self.assertRaises(ProductProvider.DoesNotExist):
+            ProductProvider.objects.get(pk=self.product_provider.pk)

--- a/backend/products/urls.py
+++ b/backend/products/urls.py
@@ -50,5 +50,10 @@ urlpatterns = [
         "category/create",
         views.CreateCategoryView.as_view(),
         name="create_category"
-    )
+    ),
+    path(
+        "<int:pk>/providers",
+        views.AddProviderToProductView.as_view(),
+        name="add_provider"
+    ),
 ]

--- a/backend/products/urls.py
+++ b/backend/products/urls.py
@@ -56,4 +56,9 @@ urlpatterns = [
         views.AddProviderToProductView.as_view(),
         name="add_provider"
     ),
+    path(
+        "productproviders/<int:pk>",
+        views.RemoveProviderFromProductView.as_view(),
+        name="delete_product_provider"
+    )
 ]

--- a/backend/products/views.py
+++ b/backend/products/views.py
@@ -350,13 +350,7 @@ class AddProviderToProductView(APIView):
 
     def post(self, request: Request, *args, **kwargs) -> Response:
         data = request.data
-        target = Product.objects.get(pk=kwargs.get('pk'))
-        if not target:
-            return Response(
-                data={"code": "TARGET_PRODUCT_NOT_FOUND"},
-                status=status.HTTP_400_BAD_REQUEST
-            )
-
+        target = generics.get_object_or_404(Product, pk=kwargs.get('pk'))
         serializer = AddProviderToProductSerializer(
             data={
                 **data,
@@ -372,4 +366,19 @@ class AddProviderToProductView(APIView):
         return Response(
             data={'code': 'PROVIDER_ADDED'},
             status=status.HTTP_201_CREATED,
+        )
+
+
+class RemoveProviderFromProductView(APIView):
+    permission_classes = (IsAdmin, )
+
+    def delete(self, request: Request, *args, **kwargs) -> Response:
+        target = generics.get_object_or_404(
+            ProductProvider,
+            pk=kwargs.get('pk'),
+        )
+        target.delete()
+        return Response(
+            data={'code': 'PROVIDER_REMOVED'},
+            status=status.HTTP_200_OK,
         )

--- a/backend/products/views.py
+++ b/backend/products/views.py
@@ -30,6 +30,7 @@ from providers.models import Provider
 
 from products.serializers.product import (
     AcceptProductSerializer,
+    AddProviderToProductSerializer,
     CreateProductSerializer,
     ListProductSerializer, ListProviderProductsSerializer,
     ProductSerializer,
@@ -342,3 +343,33 @@ class CreateCategoryView(generics.CreateAPIView):
 class ListCategoryView(generics.ListAPIView):
     queryset = Category.objects.all()
     serializer_class = ListCategorySerializer
+
+
+class AddProviderToProductView(APIView):
+    permission_classes = (IsAdmin, )
+
+    def post(self, request: Request, *args, **kwargs) -> Response:
+        data = request.data
+        target = Product.objects.get(pk=kwargs.get('pk'))
+        if not target:
+            return Response(
+                data={"code": "TARGET_PRODUCT_NOT_FOUND"},
+                status=status.HTTP_400_BAD_REQUEST
+            )
+
+        serializer = AddProviderToProductSerializer(
+            data={
+                **data,
+                'product': target.pk,
+            }
+        )
+        if not serializer.is_valid():
+            return Response(
+                data=serializer.errors,
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        serializer.save()
+        return Response(
+            data={'code': 'PROVIDER_ADDED'},
+            status=status.HTTP_201_CREATED,
+        )

--- a/frontend/src/@types/provider.d.ts
+++ b/frontend/src/@types/provider.d.ts
@@ -7,6 +7,7 @@ export interface Provider extends CommonType {
   rfc: string;
   address: string;
   emails?: UserEmail[];
+  nav_key: string;
 }
 
 export interface CreateProviderForm extends CreateBusinessForm {

--- a/frontend/src/components/Modals/AddProviderToProductModal/AddProviderToProduct.type.ts
+++ b/frontend/src/components/Modals/AddProviderToProductModal/AddProviderToProduct.type.ts
@@ -1,0 +1,7 @@
+import { ProductGroup } from '@types';
+
+export interface Props {
+  visible: boolean;
+  onClose: (success: boolean) => void;
+  product: ProductGroup;
+}

--- a/frontend/src/components/Modals/AddProviderToProductModal/AddProviderToProductModal.tsx
+++ b/frontend/src/components/Modals/AddProviderToProductModal/AddProviderToProductModal.tsx
@@ -1,0 +1,219 @@
+import { Laboratory, Provider } from '@types';
+import {
+  Modal,
+  notification,
+  Form,
+  Select,
+  InputNumber,
+} from 'antd';
+import LoadingIndicator from 'components/LoadingIndicator';
+import { useBackend } from 'integrations';
+import React, { useCallback, useEffect, useState } from 'react';
+import { Props } from './AddProviderToProduct.type';
+
+const { Option } = Select;
+
+interface GroupProductForm {
+  product: number;
+}
+
+const AddProviderToProductModal: React.FC<Props> = ({
+  visible, onClose, product,
+}) => {
+  const [form] = Form.useForm<GroupProductForm>();
+
+  const [loading, setLoading] = useState(false);
+  const [
+    labs, setLabs,
+  ] = useState<Laboratory[] | undefined>(undefined);
+  const [
+    providers, setProviders,
+  ] = useState<Provider[] | undefined>(undefined);
+  const backend = useBackend();
+
+  const onFinishFailed = (code: string) : void => {
+    switch (code) {
+      default:
+        notification.error({
+          message: '¡Ocurrió un error al intentar guardar!',
+          description: 'Intentalo después.',
+        });
+        break;
+    }
+  };
+  const fetchLabs = useCallback(async () => {
+    setLoading(true);
+
+    const [result, error] = await backend.laboratory.getAll();
+
+    if (error || !result) {
+      notification.error({
+        message: 'Ocurrió un error al cargar los laboratorios!',
+        description: 'Intentalo más tarde',
+      });
+      setLoading(false);
+      return;
+    }
+
+    setLabs(result.data);
+    setLoading(false);
+  }, [backend.laboratory]);
+
+  const fetchProviders = useCallback(async () => {
+    setLoading(true);
+
+    const [result, error] = await backend.providers.getAll();
+
+    if (error || !result) {
+      notification.error({
+        message: 'Ocurrió un error al cargar la lista de proveedores!',
+        description: 'Intentalo más tarde',
+      });
+      setLoading(false);
+      return;
+    }
+
+    setProviders(result.data);
+    setLoading(false);
+  }, [backend.providers]);
+
+  useEffect(() => {
+    if (labs === undefined) {
+      fetchLabs();
+    }
+    if (providers === undefined) {
+      fetchProviders();
+    }
+  }, [fetchLabs, fetchProviders, labs, providers]);
+
+  const handleUpdate = async (data: any): Promise<void> => {
+    setLoading(true);
+
+    const [response, error] = await backend.products.post(
+      `/${product.id}/providers`, data,
+    );
+
+    if (error || !response || !response.data) {
+      onFinishFailed(error?.response?.data.code);
+      setLoading(false);
+      return;
+    }
+
+    notification.success({
+      message: (
+        'Se ha agregado el proveedor exitosamente'
+      ),
+    });
+
+    setLoading(false);
+    onClose(true);
+  };
+
+  const handleOk = async (): Promise<void> => {
+    const values = await form.validateFields();
+    await handleUpdate(values);
+  };
+
+  const availableProviders = (): Provider[] => {
+    if (!providers || !product) {
+      return [];
+    }
+    // Find providers not associated with product.
+    return providers.filter(
+      (provider) => !product.providers.some(
+        (productsProvider) => productsProvider.provider === provider.name,
+      ),
+    );
+  };
+
+  return (
+    <Modal
+      visible={visible}
+      onCancel={() => onClose(false)}
+      onOk={handleOk}
+      okText="Confirmar"
+      cancelText="Cancelar"
+      title={`Agregar proveedor a producto: ${product.name}`}
+      confirmLoading={loading}
+    >
+      { labs && providers
+        ? (
+          <Form
+            form={form}
+          >
+            <Form.Item
+              name="provider"
+              rules={[{ required: true }]}
+              label="Proveedor"
+            >
+              <Select
+                showSearch
+                placeholder="Buscar proveedor"
+                filterOption={
+                    (input, option) => (option === undefined
+                      ? false : option.children
+                        .toLowerCase().indexOf(input.toLowerCase()) >= 0)
+                    }
+              >
+                { Object.values(availableProviders().map(
+                  (provider) => (
+                    <Option value={provider.id} key={provider.id}>
+                      {`${provider.name} - ${provider.nav_key}`}
+                    </Option>
+                  ),
+                ))}
+              </Select>
+            </Form.Item>
+            <Form.Item
+              name="laboratory"
+              rules={[{ required: true }]}
+              label="Laboratorio"
+            >
+              <Select
+                showSearch
+                placeholder="Buscar laboratorio"
+                filterOption={
+                    (input, option) => (option === undefined
+                      ? false : option.children
+                        .toLowerCase().indexOf(input.toLowerCase()) >= 0)
+                    }
+              >
+                { Object.values(labs.map(
+                  (lab) => (
+                    <Option value={lab.id} key={lab.id}>
+                      {`${lab.name}`}
+                    </Option>
+                  ),
+                ))}
+              </Select>
+            </Form.Item>
+            <Form.Item
+              name="price"
+              label="Precio"
+              rules={[{ required: true }]}
+            >
+              <InputNumber
+                min={0.01}
+                style={{ width: '100%' }}
+                formatter={(value) => `$ ${value}`.replace(
+                  /\B(?=(\d{3})+(?!\d))/g, ',',
+                )}
+              />
+            </Form.Item>
+            <Form.Item
+              name="iva"
+              label="IVA (%)"
+              rules={[{ required: true }]}
+            >
+              <Select>
+                <Option value="0.00" key="0.00"> 0.00 %</Option>
+                <Option value="16.00" key="16.00"> 16.00 %</Option>
+              </Select>
+            </Form.Item>
+          </Form>
+        ) : <LoadingIndicator /> }
+    </Modal>
+  );
+};
+
+export default AddProviderToProductModal;

--- a/frontend/src/components/Modals/AddProviderToProductModal/index.ts
+++ b/frontend/src/components/Modals/AddProviderToProductModal/index.ts
@@ -1,0 +1,1 @@
+export { default } from './AddProviderToProductModal';

--- a/frontend/src/components/OrderSummary/OrderSummary.tsx
+++ b/frontend/src/components/OrderSummary/OrderSummary.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {
-  Typography, Row, Col, Divider, Card,
+  Typography, Row, Col, Card,
 } from 'antd';
 import moment from 'moment';
 import { Props } from './OrderSummary.type';
@@ -23,7 +23,6 @@ const OrderSummary: React.FC<Props> = ({ order }) => {
           { value }
         </Text>
       </Col>
-      <Divider />
     </Row>
   );
 
@@ -50,7 +49,6 @@ const OrderSummary: React.FC<Props> = ({ order }) => {
     <Card style={{
       marginRight: '15em',
       marginLeft: '15em',
-      marginBottom: '3em',
     }}
     >
       <Row justify="center">

--- a/frontend/src/constants/featureFlags.ts
+++ b/frontend/src/constants/featureFlags.ts
@@ -9,3 +9,4 @@ export const SHOW_ADD_OFFER_BTN = true;
 export const SHOW_CREATE_USER = false;
 export const SHOW_USERS_LIST = true;
 export const SHOW_CANCEL_OFFER_BTN = true;
+export const SHOW_ADD_PROVIDER_TO_PRODUCT = true;

--- a/frontend/src/constants/featureFlags.ts
+++ b/frontend/src/constants/featureFlags.ts
@@ -10,3 +10,4 @@ export const SHOW_CREATE_USER = false;
 export const SHOW_USERS_LIST = true;
 export const SHOW_CANCEL_OFFER_BTN = true;
 export const SHOW_ADD_PROVIDER_TO_PRODUCT = true;
+export const SHOW_REMOVE_PROVIDER_FROM_PRODUCT = true;

--- a/frontend/src/views/Products.ListProducts/Products.ListProducts.tsx
+++ b/frontend/src/views/Products.ListProducts/Products.ListProducts.tsx
@@ -18,7 +18,7 @@ import LoadingIndicator from 'components/LoadingIndicator/LoadingIndicator';
 import {
   EditOutlined, PlusOutlined,
   SearchOutlined, StopOutlined,
-  ShoppingCartOutlined, TagOutlined, UserAddOutlined,
+  ShoppingCartOutlined, TagOutlined, UserAddOutlined, MinusCircleOutlined,
 } from '@ant-design/icons';
 import useAuth from 'hooks/useAuth';
 import useShoppingCart from 'hooks/shoppingCart';
@@ -28,6 +28,7 @@ import {
   SHOW_ADD_TO_CART_BTN,
   SHOW_CANCEL_OFFER_BTN,
   SHOW_EDIT_PRODUCT,
+  SHOW_REMOVE_PROVIDER_FROM_PRODUCT,
 } from 'constants/featureFlags';
 import CreateProductOfferModal from 'components/Modals/CreateProductOfferModal';
 import DiscountText from 'components/DiscountText';
@@ -81,6 +82,7 @@ const ListProducts: React.VC = ({ verboseName, parentName }) => {
     isProvider || isAdmin
   );
   const shouldShowAddProvider = SHOW_ADD_PROVIDER_TO_PRODUCT && isAdmin;
+  const shouldShowRemoveProvider = SHOW_REMOVE_PROVIDER_FROM_PRODUCT && isAdmin;
 
   const fetchProducts = useCallback(async () => {
     setLoading(true);
@@ -119,6 +121,29 @@ const ListProducts: React.VC = ({ verboseName, parentName }) => {
     notification.success({
       message: 'Se ha cancelado la oferta exitosamente.',
       description: 'El producto ha regresado a su precio original',
+    });
+    fetchProducts();
+  };
+
+  const onRemoveProvider = async (
+    pk: number,
+  ) : Promise<void> => {
+    setLoading(true);
+    const [result, error] = await backend.products.delete(
+      `/productproviders/${pk}`,
+    );
+    if (error || !result) {
+      notification.error({
+        message: 'Ocurrió un error al desagrupar al proveedor!',
+        description: 'Intentalo más tarde',
+      });
+      setLoading(false);
+      return;
+    }
+    setLoading(false);
+
+    notification.success({
+      message: 'Se ha desagrupado al proveedor del producto exitosamente.',
     });
     fetchProducts();
   };
@@ -289,6 +314,26 @@ const ListProducts: React.VC = ({ verboseName, parentName }) => {
                     shape="circle"
                     icon={<StopOutlined />}
                     disabled={provider.offer === null}
+                  />
+                </Popconfirm>
+              </Tooltip>
+              )}
+            </Col>
+            <Col>
+              {shouldShowRemoveProvider && (
+              <Tooltip title="Desagrupar proveedor de producto">
+                <Popconfirm
+                  title={'¿Está seguro que desea desagrupar al proveedor '
+                  + `${provider.provider} del producto: ${product.name}?`}
+                  onConfirm={
+                    () => onRemoveProvider(
+                      provider.id,
+                    )
+                  }
+                >
+                  <Button
+                    shape="circle"
+                    icon={<MinusCircleOutlined />}
                   />
                 </Popconfirm>
               </Tooltip>

--- a/frontend/src/views/Products.ListProducts/Products.ListProducts.tsx
+++ b/frontend/src/views/Products.ListProducts/Products.ListProducts.tsx
@@ -17,12 +17,14 @@ import AddToCart from 'components/TableCellActions/AddToCart';
 import LoadingIndicator from 'components/LoadingIndicator/LoadingIndicator';
 import {
   EditOutlined, PlusOutlined,
-  SearchOutlined, StopOutlined, ShoppingCartOutlined, TagOutlined,
+  SearchOutlined, StopOutlined,
+  ShoppingCartOutlined, TagOutlined, UserAddOutlined,
 } from '@ant-design/icons';
 import useAuth from 'hooks/useAuth';
 import useShoppingCart from 'hooks/shoppingCart';
 import {
   SHOW_ADD_OFFER_BTN,
+  SHOW_ADD_PROVIDER_TO_PRODUCT,
   SHOW_ADD_TO_CART_BTN,
   SHOW_CANCEL_OFFER_BTN,
   SHOW_EDIT_PRODUCT,
@@ -30,11 +32,18 @@ import {
 import CreateProductOfferModal from 'components/Modals/CreateProductOfferModal';
 import DiscountText from 'components/DiscountText';
 import TableFilter from 'components/TableFilter';
+import AddProviderToProductModal
+  from 'components/Modals/AddProviderToProductModal';
 import { Actions } from './Products.ListProducts.styled';
 
 interface OfferModal {
   visible: boolean,
   provider: ProductProvider | undefined,
+}
+
+interface AddProviderModal {
+  visible: boolean,
+  product: ProductGroup | undefined,
 }
 
 const ListProducts: React.VC = ({ verboseName, parentName }) => {
@@ -48,6 +57,11 @@ const ListProducts: React.VC = ({ verboseName, parentName }) => {
   const [offerModal, setOfferModal] = useState<OfferModal>(
     { visible: false, provider: undefined },
   );
+
+  const [addProviderModal, setAddProviderModal] = useState<AddProviderModal>(
+    { visible: false, product: undefined },
+  );
+
   const [isLoading, setLoading] = useState(false);
   const [
     products, setProducts,
@@ -66,6 +80,7 @@ const ListProducts: React.VC = ({ verboseName, parentName }) => {
   const shouldShowCancelOffer = SHOW_CANCEL_OFFER_BTN && (
     isProvider || isAdmin
   );
+  const shouldShowAddProvider = SHOW_ADD_PROVIDER_TO_PRODUCT && isAdmin;
 
   const fetchProducts = useCallback(async () => {
     setLoading(true);
@@ -193,6 +208,20 @@ const ListProducts: React.VC = ({ verboseName, parentName }) => {
                 onClick={() => (
                   history.push(`/productos/${product.id}/modificar`)
                 )}
+              />
+            </Tooltip>
+          ) : null}
+          {shouldShowAddProvider ? (
+            <Tooltip title="Agregar proveedor">
+              <Button
+                style={{ marginRight: '1em' }}
+                shape="circle"
+                icon={<UserAddOutlined />}
+                onClick={() => (
+                  setAddProviderModal({
+                    visible: true,
+                    product,
+                  }))}
               />
             </Tooltip>
           ) : null}
@@ -356,6 +385,7 @@ const ListProducts: React.VC = ({ verboseName, parentName }) => {
       fetchProducts();
     }
     setOfferModal({ ...offerModal, visible: false });
+    setAddProviderModal({ ...addProviderModal, visible: false });
   };
 
   const onFilterAny = (
@@ -453,6 +483,15 @@ const ListProducts: React.VC = ({ verboseName, parentName }) => {
                 visible={offerModal.visible}
                 onClose={onCloseModal}
                 product={offerModal.provider}
+              />
+            ) : null}
+          { shouldShowAddProvider
+           && addProviderModal.product
+            ? (
+              <AddProviderToProductModal
+                visible={addProviderModal.visible}
+                onClose={onCloseModal}
+                product={addProviderModal.product}
               />
             ) : null}
         </>

--- a/frontend/src/views/Products.ListProducts/Products.ListProducts.tsx
+++ b/frontend/src/views/Products.ListProducts/Products.ListProducts.tsx
@@ -148,13 +148,6 @@ const ListProducts: React.VC = ({ verboseName, parentName }) => {
     fetchProducts();
   };
 
-  const onOrderFailed = () : void => {
-    notification.error({
-      message: '¡Ocurrió un error al intentar generar la orden de compra!',
-      description: 'Intentalo después.',
-    });
-  };
-
   const createOrder = async () : Promise<void> => {
     setLoading(true);
     if (productsSh.length > 0) {


### PR DESCRIPTION
## ¿Qué hace este PR?
- Agrega funcionalidad para agregar un nuevo proveedor directamente desde un producto existente, ingresando desde un modal los campos específicos del proveedor (precio, iva, laboratorio). En el campo de proveedor, se filtran los que ya estan asociados al producto.
- Agrega funcionalidad para eliminar la relación de un producto proveedor para desagrupar a un proveedor de un producto
- Desactiva logger al correr pruebas

## ¿Cuáles son los tickets relevantes de JIRA?
- GAQ-225
- GAQ-228

## Screenshots (Si aplica)
![image](https://user-images.githubusercontent.com/38927620/143513852-30132683-5ee5-4cb9-9824-98bf09baf9f1.png)
![image](https://user-images.githubusercontent.com/38927620/143514009-a14d174f-8339-46ac-8be6-5fd2f1f029a6.png)

## Preguntas
Siento que se esta amontonando mucho las acciones que se puede tener en la lista de productos. Aunque a GAQSA le guste que todo este lo mas pegado posible siento que se puede ver raro si seguimos agregando botones. Alguna idea que se les occurra?

