### PR TITLE
fix: create order detail redirect [GAQ-233]

### DIFF
--- a/frontend/src/Routes/index.ts
+++ b/frontend/src/Routes/index.ts
@@ -27,6 +27,7 @@ import ListProviders from 'views/Providers.ListProviders';
 import ListAuditLog from 'views/AuditLog.ListAuditLog';
 import ListInvoice from 'views/Invoice.ListInvoice';
 import UploadInvoice from 'views/Invoice.UploadInvoice/Invoice.UploadInvoice';
+import OrderCreateOrder from 'views/Order.CreateOrder';
 
 import {
   LIST_PROVIDERS, SHOW_CREATE_ANNOUNCEMENT,
@@ -36,7 +37,6 @@ import {
   SHOW_AUDIT_LOG, SHOW_DETAIL_ANNOUNCEMENT,
 } from 'constants/featureFlags';
 import { AuthType } from 'hooks/useAuth';
-import OrderCreateOrder from 'views/Order.CreateOrder';
 
 export interface RoutesType {
   path: string;
@@ -70,7 +70,7 @@ export const productRoutes: Routes = {
     hasAccess: ((auth) => auth.isProvider || auth.isAdmin),
   },
   updateProduct: {
-    path: '/productos/:id/modificar',
+    path: '/productos/:id(\\d+)/modificar',
     view: ProductsUpdateForm,
     verboseName: 'Modificar producto',
     hasAccess: ((auth) => auth.isAdmin || auth.isProvider),
@@ -90,7 +90,7 @@ export const productRoutes: Routes = {
     hasAccess: ((auth) => auth.isClient || auth.isAdmin || auth.isProvider),
   },
   detailProduct: {
-    path: '/productos/:id/detalle',
+    path: '/productos/:id(\\d+)/detalle',
     view: ProductsDetail,
     verboseName: 'Modificar producto',
     showInMenu: false,
@@ -106,7 +106,7 @@ export const productRoutes: Routes = {
 
 const ordersRoutes: Routes = {
   orderDetail: {
-    path: '/pedidos/:id',
+    path: '/pedidos/:id(\\d+)',
     view: OrderDetail,
     verboseName: 'Detalle de pedido',
     showInMenu: false,
@@ -125,13 +125,13 @@ const ordersRoutes: Routes = {
        || auth.isProvider || auth.isInvoiceManager),
   },
   updateOrder: {
-    path: '/pedidos/:id/modificar',
+    path: '/pedidos/:id(\\d+)(\\d+)/modificar',
     view: OrderUpdate,
     verboseName: 'Modificar pedido',
     hasAccess: (auth) => auth.isProvider || auth.isAdmin,
   },
   createOrder: {
-    path: '/pedidos',
+    path: '/pedidos/resumen',
     view: OrderCreateOrder,
     verboseName: 'Resumen de Orden',
     showInMenu: true,
@@ -221,7 +221,7 @@ export const catalogsRoutes: Routes = {
     ),
   },
   detailAnnouncements: {
-    path: '/circulares/:id',
+    path: '/circulares/:id(\\d+)',
     view: AnnouncementsDetailCompound,
     verboseName: 'Detalle de circulare',
     showInMenu: SHOW_DETAIL_ANNOUNCEMENT,

--- a/frontend/src/views/Order.CreateOrder/Order.CreateOrder.tsx
+++ b/frontend/src/views/Order.CreateOrder/Order.CreateOrder.tsx
@@ -20,7 +20,6 @@ import { ProductGroup } from '@types';
 import LoadingIndicator from 'components/LoadingIndicator';
 import Table from 'components/Table';
 import FormButton from 'components/FormButton';
-import useAuth from 'hooks/useAuth';
 import DiscountText from 'components/DiscountText';
 import Text from 'antd/lib/typography/Text';
 
@@ -48,8 +47,6 @@ const CreateOrder: React.VC = ({ verboseName, parentName }) => {
   const history = useHistory();
   const [isLoading, setLoading] = useState(false);
 
-  const { user } = useAuth();
-
   const {
     productsSh, addProducts, removeProducts, clear, total, subieps, subiva,
     subtotal,
@@ -64,26 +61,24 @@ const CreateOrder: React.VC = ({ verboseName, parentName }) => {
 
   const onFinish = async () : Promise<void> => {
     setLoading(true);
-    if (user) {
-      const [, error] = await backend.orders.createOne({
-        productsSh,
-      });
+    const [, error] = await backend.orders.createOne({
+      productsSh,
+    });
 
-      if (error) {
-        onFinishFailed();
-        return;
-      }
-      clear();
-      notification.success({
-        message: '¡Petición de orden creado exitosamente!',
-        description: 'Su orden de compra ha sido recibida y será procesada'
+    if (error) {
+      onFinishFailed();
+      return;
+    }
+    clear();
+    notification.success({
+      message: '¡Petición de orden creado exitosamente!',
+      description: 'Su orden de compra ha sido recibida y será procesada'
             + 'El proveedor le informará lo mas pronto posible '
             + 'el estatus de su solicitud.',
-      });
-      history.replace('/pedidos/cliente');
+    });
+    history.replace('/pedidos');
 
-      setLoading(false);
-    }
+    setLoading(false);
   };
   const columns = [
     {

--- a/frontend/src/views/Products.ListProducts/Products.ListProducts.tsx
+++ b/frontend/src/views/Products.ListProducts/Products.ListProducts.tsx
@@ -183,12 +183,8 @@ const ListProducts: React.VC = ({ verboseName, parentName }) => {
     fetchProducts();
   };
 
-  const createOrder = async () : Promise<void> => {
-    setLoading(true);
-    if (productsSh.length > 0) {
-      history.push('/pedidos');
-    }
-    setLoading(false);
+  const createOrder = () : void => {
+    history.push('/pedidos/resumen');
   };
 
   const renderLabs = (
@@ -561,7 +557,13 @@ const ListProducts: React.VC = ({ verboseName, parentName }) => {
                 action: createOrder,
                 text: 'Ordenar',
                 icon: <ShoppingCartOutlined />,
+                disabled: productsSh.length === 0,
                 hidden: (isAdmin || isProvider),
+                badgeProps: {
+                  count: productsSh.length,
+                  showZero: true,
+                  color: 'green',
+                },
               },
               {
                 action: changePriceButton,


### PR DESCRIPTION
## ¿Qué hace este PR?
- Arregla las rutas de frontend para especificar que los ids pasados deben ser numéricos enteros. Esto provocaba confusión en algunas rutas de pedido.
- Agrega "Badge" al boton de compra para mostrar cuantos están en el carrito.

## ¿Cuáles son los tickets relevantes de JIRA?
- Cierra el bug GAQ-233

## Screenshots (Si aplica)
![image](https://user-images.githubusercontent.com/38927620/148606858-4e34bb8a-a324-48d7-beaa-71644bbabd2d.png)
![image](https://user-images.githubusercontent.com/38927620/148606869-9bfb2f0a-31ae-45ff-8048-cc943ec306b3.png)

