### PR TITLE
feat: send notification to users on new announcement

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,1 +1,2 @@
 DOMAIN_URL=http://localhost:8000
+FRONTEND_DOMAIN_URL=http://localhost:3000

--- a/backend/announcements/mails.py
+++ b/backend/announcements/mails.py
@@ -1,0 +1,48 @@
+from django.contrib.auth.models import User
+
+from announcements.models import Announcement
+from django.core import mail
+from django.template.loader import render_to_string
+from django.utils.html import strip_tags
+
+from backend.settings import DOMAIN_URL, FRONTEND_DOMAIN_URL
+from backend.utils.constants import PROVIDER_GROUP, CLIENT_GROUP
+
+
+def send_mail_on_create_announcement(announcement: Announcement) -> None:
+    connection = mail.get_connection(fail_silently=True)
+    connection.open()
+
+    title = announcement.title
+    subject = f"GAQSA - {title}"
+    url = f"{FRONTEND_DOMAIN_URL}/circulares/{announcement.pk}"
+    addressee = announcement.addressee
+    context = {
+        "url": url,
+        "title": title,
+        "addresee": "Proveedores" if addressee == Announcement.PROVIDERS else "Clientes"
+    }
+
+    group = PROVIDER_GROUP if addressee == Announcement.PROVIDERS else CLIENT_GROUP
+
+    provider_emails = list(User.objects.filter(
+        groups__name=group,
+    ).values_list('email', flat=True))
+
+    from_email = "noreply@gaqsa.com"
+    to_emails = provider_emails
+    html_message = render_to_string(
+        "new_announcement.html",
+        context
+    )
+    plain_message = strip_tags(html_message)
+    email = mail.EmailMultiAlternatives(
+        subject,
+        plain_message,
+        from_email,
+        to_emails,
+    )
+    email.attach_alternative(html_message, "text/html")
+
+    connection.send_messages([email])
+    connection.close()

--- a/backend/announcements/mails.py
+++ b/backend/announcements/mails.py
@@ -5,7 +5,7 @@ from django.core import mail
 from django.template.loader import render_to_string
 from django.utils.html import strip_tags
 
-from backend.settings import DOMAIN_URL, FRONTEND_DOMAIN_URL
+from backend.settings import FRONTEND_DOMAIN_URL
 from backend.utils.constants import PROVIDER_GROUP, CLIENT_GROUP
 
 
@@ -20,10 +20,18 @@ def send_mail_on_create_announcement(announcement: Announcement) -> None:
     context = {
         "url": url,
         "title": title,
-        "addresee": "Proveedores" if addressee == Announcement.PROVIDERS else "Clientes"
+        "addresee": (
+            "Proveedores"
+            if addressee == Announcement.PROVIDERS
+            else "Clientes"
+        )
     }
 
-    group = PROVIDER_GROUP if addressee == Announcement.PROVIDERS else CLIENT_GROUP
+    group = (
+        PROVIDER_GROUP
+        if addressee == Announcement.PROVIDERS
+        else CLIENT_GROUP
+    )
 
     provider_emails = list(User.objects.filter(
         groups__name=group,

--- a/backend/announcements/templates/new_announcement.html
+++ b/backend/announcements/templates/new_announcement.html
@@ -1,0 +1,10 @@
+{% extends "base_email.html" %}
+
+{% block title %}{{ title }}{% endblock %}
+
+{% block content %}
+    <div>
+        <h4>Nueva circular para {{ addresee }}</h4>
+    </div>
+    <p>Puede ver la circular completa en <a href="{{ url }}"></a></p>
+{% endblock %}

--- a/backend/announcements/views.py
+++ b/backend/announcements/views.py
@@ -3,6 +3,7 @@ from typing import Tuple
 
 from rest_framework.generics import RetrieveAPIView
 
+from announcements.mails import send_mail_on_create_announcement
 from announcements.models import Announcement
 from django.core.files.storage import default_storage
 from rest_framework import status
@@ -61,7 +62,8 @@ class CreateAnnouncement(APIView):
                 serializer.errors, status=status.HTTP_400_BAD_REQUEST,
             )
 
-        serializer.save()
+        new_announcement = serializer.save()
+        send_mail_on_create_announcement(new_announcement)
         return Response({"status": "ok"}, status=status.HTTP_201_CREATED)
 
     def get(self, request: Request) -> Response:

--- a/backend/backend/prod.wsgi.py
+++ b/backend/backend/prod.wsgi.py
@@ -25,5 +25,8 @@ def application(environ, start_response):
     os.environ['EMAIL_PORT'] = environ['PRODUCTION_EMAIL_PORT']
     os.environ['EMAIL_USE_SSL'] = 'True'
     os.environ['DOMAIN_URL'] = environ['PRODUCTION_DOMAIN_URL']
+    os.environ['FRONTEND_DOMAIN_URL'] = environ[
+        'PRODUCTION_FRONTEND_DOMAIN_URL'
+    ]
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "backend.settings")
     return get_wsgi_application()(environ, start_response)

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -287,6 +287,7 @@ MEDIA_ROOT = os.path.join(BASE_DIR, 'media/')
 INVOICE_FILE_ROOT = 'invoices/'
 
 DOMAIN_URL = os.getenv('DOMAIN_URL', '')
+FRONTEND_DOMAIN_URL = os.getenv('FRONTEND_DOMAIN_URL', '')
 
 # Weekdays enabled where admin or invoice manager can
 # update an invoice's status. Example: 0 - Monday, 1 - Tuesday...

--- a/backend/backend/staging.wsgi.py
+++ b/backend/backend/staging.wsgi.py
@@ -24,5 +24,6 @@ def application(environ, start_response):
     os.environ['EMAIL_PORT'] = environ['STAGING_EMAIL_PORT']
     os.environ['EMAIL_USE_SSL'] = 'True'
     os.environ['DOMAIN_URL'] = environ['STAGING_DOMAIN_URL']
+    os.environ['FRONTEND_DOMAIN_URL'] = environ['STAGING_FRONTEND_DOMAIN_URL']
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "backend.settings")
     return get_wsgi_application()(environ, start_response)

--- a/frontend/src/Routes/index.ts
+++ b/frontend/src/Routes/index.ts
@@ -112,7 +112,7 @@ const ordersRoutes: Routes = {
     showInMenu: false,
     hasAccess: (
       (auth) => auth.isClient || auth.isAdmin
-         || auth.isProvider || auth.isInvoiceManager
+        || auth.isProvider || auth.isInvoiceManager
     ),
   },
   listOrder: {
@@ -122,7 +122,7 @@ const ordersRoutes: Routes = {
     showInMenu: true,
     hasAccess: (
       (auth) => auth.isClient || auth.isAdmin
-       || auth.isProvider || auth.isInvoiceManager),
+        || auth.isProvider || auth.isInvoiceManager),
   },
   updateOrder: {
     path: '/pedidos/:id/modificar',
@@ -220,6 +220,13 @@ export const catalogsRoutes: Routes = {
       (auth) => auth.isAdmin || auth.isProvider || auth.isClient
     ),
   },
+  createAnnouncement: {
+    path: '/circulares/nueva',
+    view: AnnouncementsCreate,
+    verboseName: 'Nueva circular',
+    showInMenu: SHOW_CREATE_ANNOUNCEMENT,
+    hasAccess: ((auth) => auth.isAdmin),
+  },
   detailAnnouncements: {
     path: '/circulares/:id',
     view: AnnouncementsDetailCompound,
@@ -228,13 +235,6 @@ export const catalogsRoutes: Routes = {
     hasAccess: (
       (auth) => auth.isAdmin || auth.isProvider || auth.isClient
     ),
-  },
-  createAnnouncement: {
-    path: '/circulares/nueva',
-    view: AnnouncementsCreate,
-    verboseName: 'Nueva circular',
-    showInMenu: SHOW_CREATE_ANNOUNCEMENT,
-    hasAccess: ((auth) => auth.isAdmin),
   },
 };
 


### PR DESCRIPTION
## ¿Qué hace este PR?

* Ahora, al crear una nueva circular, se envía un correo a los destinatarios correspondientes. 
* Se añade una nueva variable de entorno al backend para saber el dominio del frontend. Esto es necesario para poder mandar la URL de la nueva circular por correo. 
